### PR TITLE
Update linuxify.sh

### DIFF
--- a/linuxify.sh
+++ b/linuxify.sh
@@ -23,6 +23,7 @@ linuxify_formulas=(
     "wget"
     "wdiff --with-gettext"
     "gdb"
+    "autoconf"
 
     # GNU programs whose BSD counterpart is installed in macOS
     "coreutils"


### PR DESCRIPTION
Autoconf does not come pre-installed on macOS.