### PR TITLE
Fix incorrect path on big sur

### DIFF
--- a/.linuxify
+++ b/.linuxify
@@ -60,3 +60,5 @@ export PATH="${BREW_HOME}/opt/gnu-which/libexec/gnubin:$PATH"
 
 # grep
 export PATH="${BREW_HOME}/opt/grep/libexec/gnubin:$PATH"
+
+unset BREW_HOME

--- a/.linuxify
+++ b/.linuxify
@@ -1,60 +1,62 @@
+BREW_HOME=$(brew --prefix)
+
 # most programs
-export PATH="/usr/local/bin:$PATH"
-export MANPATH="/usr/local/share/man:$MANPATH"
-export INFOPATH="/usr/local/share/info:$INFOPATH"
+export PATH="${BREW_HOME}/bin:$PATH"
+export MANPATH="${BREW_HOME}/share/man:$MANPATH"
+export INFOPATH="${BREW_HOME}/share/info:$INFOPATH"
 
 # coreutils
-export PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"
-export MANPATH="/usr/local/opt/coreutils/libexec/gnuman:$MANPATH"
+export PATH="${BREW_HOME}/opt/coreutils/libexec/gnubin:$PATH"
+export MANPATH="${BREW_HOME}/opt/coreutils/libexec/gnuman:$MANPATH"
 
 # make
-export PATH="/usr/local/opt/make/libexec/gnubin:$PATH"
-export MANPATH="/usr/local/opt/make/libexec/gnuman:$MANPATH"
+export PATH="${BREW_HOME}/opt/make/libexec/gnubin:$PATH"
+export MANPATH="${BREW_HOME}/opt/make/libexec/gnuman:$MANPATH"
 
 # m4
-export PATH="/usr/local/opt/m4/bin:$PATH"
+export PATH="${BREW_HOME}/opt/m4/bin:$PATH"
 
 # file-formula
-export PATH="/usr/local/opt/file-formula/bin:$PATH"
+export PATH="${BREW_HOME}/opt/file-formula/bin:$PATH"
 
 # unzip
-export PATH="/usr/local/opt/unzip/bin:$PATH"
+export PATH="${BREW_HOME}/opt/unzip/bin:$PATH"
 
 # python
-export PATH="/usr/local/opt/python/libexec/bin:$PATH"
+export PATH="${BREW_HOME}/opt/python/libexec/bin:$PATH"
 
 # flex
-export PATH="/usr/local/opt/flex/bin:$PATH"
-export LDFLAGS="-L/usr/local/opt/flex/lib"
-export CPPFLAGS="-I/usr/local/opt/flex/include"
+export PATH="${BREW_HOME}/opt/flex/bin:$PATH"
+export LDFLAGS="-L${BREW_HOME}/opt/flex/lib"
+export CPPFLAGS="-I${BREW_HOME}/opt/flex/include"
 
 # bison
-export PATH="/usr/local/opt/bison/bin:$PATH"
-export LDFLAGS="-L/usr/local/opt/bison/lib"
+export PATH="${BREW_HOME}/opt/bison/bin:$PATH"
+export LDFLAGS="-L${BREW_HOME}/opt/bison/lib"
 
 # libressl
-export PATH="/usr/local/opt/libressl/bin:$PATH"
-export LDFLAGS="-L/usr/local/opt/libressl/lib"
-export CPPFLAGS="-I/usr/local/opt/libressl/include"
-export PKG_CONFIG_PATH="/usr/local/opt/libressl/lib/pkgconfig"
+export PATH="${BREW_HOME}/opt/libressl/bin:$PATH"
+export LDFLAGS="-L${BREW_HOME}/opt/libressl/lib"
+export CPPFLAGS="-I${BREW_HOME}/opt/libressl/include"
+export PKG_CONFIG_PATH="${BREW_HOME}/opt/libressl/lib/pkgconfig"
 
 # ed
-export PATH="/usr/local/opt/ed/libexec/gnubin:$PATH"
+export PATH="${BREW_HOME}/opt/ed/libexec/gnubin:$PATH"
 
 # findutils
-export PATH="/usr/local/opt/findutils/libexec/gnubin:$PATH"
+export PATH="${BREW_HOME}/opt/findutils/libexec/gnubin:$PATH"
 
 # gnu-indent
-export PATH="/usr/local/opt/gnu-indent/libexec/gnubin:$PATH"
+export PATH="${BREW_HOME}/opt/gnu-indent/libexec/gnubin:$PATH"
 
 # gnu-sed
-export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"
+export PATH="${BREW_HOME}/opt/gnu-sed/libexec/gnubin:$PATH"
 
 # gnu-tar
-export PATH="/usr/local/opt/gnu-tar/libexec/gnubin:$PATH"
+export PATH="${BREW_HOME}/opt/gnu-tar/libexec/gnubin:$PATH"
 
 # gnu-which
-export PATH="/usr/local/opt/gnu-which/libexec/gnubin:$PATH"
+export PATH="${BREW_HOME}/opt/gnu-which/libexec/gnubin:$PATH"
 
 # grep
-export PATH="/usr/local/opt/grep/libexec/gnubin:$PATH"
+export PATH="${BREW_HOME}/opt/grep/libexec/gnubin:$PATH"


### PR DESCRIPTION
The brew prefix on mac os big sur is not `/usr/local`, but `/opt/homebrew`.

This PR will auto detect the prefix via `brew --prefix` command.